### PR TITLE
build: Add debug pdb to build output on Windows

### DIFF
--- a/.github/workflows/central.yml
+++ b/.github/workflows/central.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           name: windows-installer
           path: |
+            build/windows/x64/runner/Release/intiface_central.pdb
             installer/intiface-central-installer.exe
   linux:
     strategy:

--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -37,3 +37,6 @@ target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
 
 # Run the Flutter tool portions of the build. This must not be removed.
 add_dependencies(${BINARY_NAME} flutter_assemble)
+
+# Need the symbols
+target_link_options(${BINARY_NAME} PUBLIC /DEBUG:FULL)


### PR DESCRIPTION
For those times when we get a crash from Intiface on Windows but can't see why