### PR TITLE
Add FreeDesktop compliant desktop file

### DIFF
--- a/linux/com.nonpolynomial.intiface_central.desktop
+++ b/linux/com.nonpolynomial.intiface_central.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Intiface Central
+Exec=run_intiface_central
+Type=Application
+Icon=com.nonpolynomial.intiface_central
+Categories=Utility


### PR DESCRIPTION
To comply with [guidance](https://github.com/flathub/flathub/pull/5012#discussion_r1509885747).

This should also ideally be added to the upstream build system to be packaged for Linux.