### PR TITLE
Add FreeDesktop Compliant MetaInfo

### DIFF
--- a/.github/workflows/central.yml
+++ b/.github/workflows/central.yml
@@ -75,7 +75,16 @@ jobs:
       - run: flutter build linux --release --dart-define="SENTRY_DSN=${{ secrets.SENTRY_DSN }}" --dart-define="DISCORD_CLIENT_ID=${{ secrets.DISCORD_CLIENT_ID }}"
         name: flutter build
       - name: Zip Release
-        run: zip -r intiface-central-linux-${{ matrix.os }}-x64.zip build/linux/x64/release/bundle
+        run: |
+          ROOT=`pwd`
+          ZIP=$PWD/intiface-central-linux-${{ matrix.os }}-x64.zip
+          cd build/linux/x64/release/bundle
+          zip -r $ZIP ./*
+          cd $ROOT
+          cd linux/
+          zip -u $ZIP com.nonpolynomial.intiface_central.desktop
+          zip -u $ZIP com.nonpolynomial.intiface_central.metainfo.xml
+          cd $ROOT
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/linux/com.nonpolynomial.intiface_central.metainfo.xml
+++ b/linux/com.nonpolynomial.intiface_central.metainfo.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html -->
+<!-- Credits to github/nickavem for the app data, Doomsdayrs for edits -->
+<component type="desktop">
+  <id>com.nonpolynomial.intiface_central</id>
+  <metadata_license>MIT</metadata_license>
+  <name>Intiface Central</name>
+  <summary>Buttplug Frontend Application</summary>
+  <description>
+    <p>Intiface® Central is a frontend application for the Buttplug Sex Toy Control Library, for Desktop (Win/macOS/Linux) and Mobile (Android/iOS).</p>
+    <p>For users, it provides simple, friendly capabilites for managing, connecting, customizing devices.</p>
+    <p>For developers, it allows their application to connect to and control sex toys, without having to worry about constantly updating the underlying libraries or dealing with bugs and crashes in a difficult-to-debug cross langauge environment.</p>
+  </description>
+  <url type="homepage">https://intiface.com/central/</url>
+  <url type="bugtracker">https://github.com/intiface/intiface-central/issues</url>
+  <url type="faq">https://docs.intiface.com/docs/intiface-central/</url>
+  <url type="help">https://discuss.buttplug.io/</url>
+  <launchable type="desktop-id">com.nonpolynomial.intiface_central.desktop</launchable>
+  <project_license>GPL-3.0</project_license>
+	<developer id="com.nonpolyomial">
+		<name>Nonpolynomial Labs, LLC</name>
+	</developer>
+
+  <releases>
+    <release version="2.5.5" date="2024-01-29"/>
+    <release version="2.5.3" date="2023-11-17"/>
+    <release version="2.4.5" date="2023-10-09"/>
+    <release version="2.4.4" date="2023-10-06"/>
+    <release version="2.4.3" date="2023-07-23"/>
+    <release version="2.3.0" date="2023-02-20"/>
+  </releases>
+
+	<screenshots>
+		<screenshot type="default">
+			<image>https://raw.githubusercontent.com/intiface/intiface-central/main/screenshots/news.png</image>
+		</screenshot>
+		<screenshot>
+			<image>https://raw.githubusercontent.com/intiface/intiface-central/main/screenshots/devices.png</image>
+		</screenshot>
+		<screenshot>
+			<image>https://raw.githubusercontent.com/intiface/intiface-central/main/screenshots/log.png</image>
+		</screenshot>
+		<screenshot>
+			<image>https://raw.githubusercontent.com/intiface/intiface-central/main/screenshots/settings.png</image>
+		</screenshot>
+		<screenshot>
+			<image>https://raw.githubusercontent.com/intiface/intiface-central/main/screenshots/help.png</image>
+		</screenshot>
+	</screenshots>
+
+  <content_rating type="oars-1.1">
+    <content_attribute id="sex-themes">moderate</content_attribute>
+  </content_rating>
+	<categories>
+		<category>Utility</category>
+	</categories>
+</component>


### PR DESCRIPTION
To comply with [guidance](https://github.com/flathub/flathub/pull/5012#discussion_r1509885865).

Ideally, the metainfo is updated before each release with release information, then bundled in with the distributed tar.

[FreeDesktop Documentation on Release Information](https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Releases.html)

Depends on: #122 