### PR TITLE
Fix unselected icon color in navigation bar

### DIFF
--- a/lib/widget/body_widget.dart
+++ b/lib/widget/body_widget.dart
@@ -70,7 +70,7 @@ class BodyWidget extends StatelessWidget {
           (state) => state is NavigationStateLogs,
           (NavigationCubit cubit) => cubit.goLogs(),
           Icon(Icons.text_snippet_outlined,
-              color: errorNotifierCubit.state is ErrorNotifierTriggerState ? Colors.red : IconTheme.of(context).color),
+              color: errorNotifierCubit.state is ErrorNotifierTriggerState ? Colors.red : null),
           const Icon(Icons.text_snippet),
           'Log',
           () => const LogPage(),
@@ -82,11 +82,11 @@ class BodyWidget extends StatelessWidget {
           Icon(Icons.settings_outlined,
               color: isDesktop() && configCubit.currentAppVersion != configCubit.latestAppVersion
                   ? Colors.green
-                  : IconTheme.of(context).color),
+                  : null),
           Icon(Icons.settings,
               color: isDesktop() && configCubit.currentAppVersion != configCubit.latestAppVersion
                   ? Colors.green
-                  : IconTheme.of(context).color),
+                  : null),
           'Settings',
           () => const SettingPage(),
           true,


### PR DESCRIPTION
The unselected icon color was incorrectly themed for the Settings and Log destinations. This just uses null as the color when not in one of the special log/settings states and NavigationBar themes it.

Before:
![image](https://github.com/user-attachments/assets/d515a30a-c2d6-4e32-911a-ee70e597921c)

After:
![image](https://github.com/user-attachments/assets/5e77ce83-0343-42ad-b7a9-ed3d027b8435)
