### PR TITLE
fix: Correct the loading of the device-config when no user-config exists

### DIFF
--- a/lib/bloc/device_configuration/user_device_configuration_cubit.dart
+++ b/lib/bloc/device_configuration/user_device_configuration_cubit.dart
@@ -28,9 +28,6 @@ class UserDeviceConfigurationCubit extends Cubit<UserDeviceConfigurationState> {
 
   Future<void> loadConfig() async {
     try {
-      if (!IntifacePaths.userDeviceConfigFile.existsSync()) {
-        return;
-      }
       String? deviceConfig;
       String? userConfig;
       if (IntifacePaths.deviceConfigFile.existsSync()) {

--- a/lib/intiface_central_app.dart
+++ b/lib/intiface_central_app.dart
@@ -275,9 +275,11 @@ class IntifaceCentralApp extends StatelessWidget with WindowListener {
     // Bring up the FFI now that we have logging available and crash logging set up.
     initializeApi();
 
+    // Setup logging before initializing the DCM
+    var apiLog = NativeApiLog();
+
     var userConfigCubit = await UserDeviceConfigurationCubit.create();
 
-    var apiLog = NativeApiLog();
     apiLog.logMessageStream.listen((message) {
       var level = message.level;
       if (level == "DEBUG") {


### PR DESCRIPTION
This fix also corrects order of the logging/DCM initialization.

Fixes #157