### PR TITLE
Add Discord Rich Presence support.

### DIFF
--- a/lib/bloc/configuration/intiface_configuration_cubit.dart
+++ b/lib/bloc/configuration/intiface_configuration_cubit.dart
@@ -168,6 +168,11 @@ class RestoreWindowLocation extends IntifaceConfigurationState {
   RestoreWindowLocation(this.value);
 }
 
+class UseDiscordRichPresence extends IntifaceConfigurationState {
+  final bool value;
+  UseDiscordRichPresence(this.value);
+}
+
 class ShowRepeaterModeState extends IntifaceConfigurationState {
   final bool value;
   ShowRepeaterModeState(this.value);
@@ -215,6 +220,7 @@ class IntifaceConfigurationCubit extends Cubit<IntifaceConfigurationState> {
     useSideNavigationBar = _prefs.getBool("useSideNavigationBar") ?? isDesktop();
     useLightTheme = _prefs.getBool("useLightTheme") ?? true;
     restoreWindowLocation = _prefs.getBool("restoreWindowLocation") ?? true;
+    useDiscordRichPresence = _prefs.getBool("useDiscordRichPresence") ?? false;
 
     // True on all platforms
     useBluetoothLE = _prefs.getBool("useBluetoothLE") ?? true;
@@ -295,6 +301,12 @@ class IntifaceConfigurationCubit extends Cubit<IntifaceConfigurationState> {
   set restoreWindowLocation(bool value) {
     _prefs.setBool("restoreWindowLocation", value);
     emit(RestoreWindowLocation(value));
+  }
+
+  bool get useDiscordRichPresence => _prefs.getBool("useDiscordRichPresence")!;
+  set useDiscordRichPresence(bool value) {
+    _prefs.setBool("useDiscordRichPresence", value);
+    emit(UseDiscordRichPresence(value));
   }
 
   String get serverName => _prefs.getString("serverName")!;

--- a/lib/bloc/device/device_manager_bloc.dart
+++ b/lib/bloc/device/device_manager_bloc.dart
@@ -61,6 +61,7 @@ class DeviceManagerBloc extends Bloc<DeviceManagerEvent, DeviceManagerState> {
       var client = ButtplugClient("Backdoor Client");
       // This is infallible due to our connector.
       await client.connect(connector);
+
       // Hook up our event listeners so we register new online devices as we get device added messages.
       client.eventStream.listen((event) {
         if (event is DeviceAddedEvent) {

--- a/lib/bloc/util/discord_cubit.dart
+++ b/lib/bloc/util/discord_cubit.dart
@@ -1,0 +1,93 @@
+import 'package:bloc/bloc.dart';
+import 'package:buttplug/client/client_device.dart';
+import 'package:buttplug/messages/enums.dart';
+import 'package:discord_rich_presence/discord_rich_presence.dart';
+import 'package:intiface_central/bloc/device/device_cubit.dart';
+import 'package:intiface_central/bloc/device/device_sensor_cubit.dart';
+
+class DiscordEvent {}
+
+class DiscordConnectedEvent extends DiscordEvent {}
+
+class DiscordEngineStartedEvent extends DiscordEvent {}
+
+class DiscordEngineStoppedEvent extends DiscordEvent {}
+
+class DiscordDeviceAddedEvent extends DiscordEvent {
+  final DeviceCubit device;
+
+  DiscordDeviceAddedEvent(this.device);
+}
+
+class DiscordDeviceRemovedEvent extends DiscordEvent {
+  final DeviceCubit device;
+
+  DiscordDeviceRemovedEvent(this.device);
+}
+
+class DiscordState {}
+
+class DiscordNotReadyState extends DiscordState {}
+
+class DiscordReadyState extends DiscordState {}
+
+class DiscordBloc extends Bloc<DiscordEvent, DiscordState> {
+  final String _clientId = const String.fromEnvironment("DISCORD_CLIENT_ID");
+  final List<DeviceCubit> _devices = [];
+  
+  Client? _discordClient;
+  DateTime? _startTime;
+
+  DiscordBloc() : super(DiscordNotReadyState()) {
+    on<DiscordEngineStartedEvent>((event, emit) async {
+      _startTime = DateTime.now();
+      _discordClient = Client(clientId: _clientId);
+
+      await _discordClient?.connect();
+      await updateDiscordStatus();
+    });
+
+    on<DiscordEngineStoppedEvent>((event, emit) async {
+      await _discordClient?.disconnect();
+
+      _discordClient = null;
+      _startTime = null;
+      _devices.clear();
+    });
+
+    on<DiscordDeviceAddedEvent>((event, emit) async {
+      _devices.add(event.device);
+      await updateDiscordStatus();
+    });
+
+    on<DiscordDeviceRemovedEvent>((event, emit) async {
+      _devices.remove(event.device);
+      await updateDiscordStatus();
+    });
+  }
+
+  Future<void> updateDiscordStatus() async {
+    final List<DeviceCubit> connectedDevices = _devices.where((device) => device.device?.connected ?? false).toList();
+    String details = "No toys connected.";
+  
+    if (connectedDevices.length == 1) {
+      DeviceCubit device = connectedDevices.first;
+      details = "${device.device?.name} connected.";
+    }
+
+    if (connectedDevices.length > 1) {
+      details = "${connectedDevices.length} toys connected.";
+    }
+
+    await _discordClient?.setActivity(
+      Activity(
+        type: ActivityType.playing,
+        name: "Intiface Central",
+        details: details,
+        timestamps: ActivityTimestamps(
+          start: _startTime!
+        ),
+      ),
+    );
+  }
+}

--- a/lib/bloc/util/discord_cubit.dart
+++ b/lib/bloc/util/discord_cubit.dart
@@ -1,9 +1,6 @@
 import 'package:bloc/bloc.dart';
-import 'package:buttplug/client/client_device.dart';
-import 'package:buttplug/messages/enums.dart';
 import 'package:discord_rich_presence/discord_rich_presence.dart';
 import 'package:intiface_central/bloc/device/device_cubit.dart';
-import 'package:intiface_central/bloc/device/device_sensor_cubit.dart';
 
 class DiscordEvent {}
 

--- a/lib/intiface_central_app.dart
+++ b/lib/intiface_central_app.dart
@@ -19,6 +19,7 @@ import 'package:intiface_central/bloc/update/update_bloc.dart';
 import 'package:intiface_central/bloc/update/update_repository.dart';
 import 'package:intiface_central/bloc/util/app_reset_cubit.dart';
 import 'package:intiface_central/bloc/util/asset_cubit.dart';
+import 'package:intiface_central/bloc/util/discord_cubit.dart';
 import 'package:intiface_central/bloc/util/error_notifier_cubit.dart';
 import 'package:intiface_central/bloc/util/gui_settings_cubit.dart';
 import 'package:intiface_central/bloc/util/navigation_cubit.dart';
@@ -298,6 +299,8 @@ class IntifaceCentralApp extends StatelessWidget with WindowListener {
       await api!.crashReporting(sentryApiKey: const String.fromEnvironment('SENTRY_DSN'));
     }
 
+    var discordBloc = DiscordBloc();
+
     engineControlBloc.stream.listen((state) async {
       if (state is ProviderLogMessageState) {
         // TODO Turn level into an enum
@@ -318,15 +321,35 @@ class IntifaceCentralApp extends StatelessWidget with WindowListener {
       }
       if (state is EngineServerCreatedState) {
         deviceControlBloc.add(DeviceManagerEngineStartedEvent());
+        if (isDesktop() && configCubit.useDiscordRichPresence) {
+          discordBloc.add(DiscordEngineStartedEvent());
+        }
       }
       if (state is EngineStoppedState) {
         deviceControlBloc.add(DeviceManagerEngineStoppedEvent());
+        if (isDesktop() && configCubit.useDiscordRichPresence) {
+          discordBloc.add(DiscordEngineStoppedEvent());
+        }
       }
       if (state is DeviceConnectedState) {
         logInfo("Updating device ${state.name} index to ${state.index}");
         await userConfigCubit.update();
       }
     });
+
+    if (isDesktop()) {
+      deviceControlBloc.stream.listen((state) async {
+        if (!configCubit.useDiscordRichPresence) return;
+
+        if (state is DeviceManagerDeviceOnlineState) {
+          discordBloc.add(DiscordDeviceAddedEvent((state).device));
+        }
+
+        if (state is DeviceManagerDeviceOfflineState) {
+          discordBloc.add(DiscordDeviceRemovedEvent((state).device));
+        }
+      });
+    }
 
     if (kDebugMode) {
       // Make sure the engine is stopped, just in case we've reloaded.
@@ -363,6 +386,8 @@ class IntifaceCentralApp extends StatelessWidget with WindowListener {
       BlocProvider(create: (context) => errorNotifierCubit),
       BlocProvider(create: (context) => userConfigCubit),
       BlocProvider(create: (context) => guiSettingsCubit),
+      // Discord RPC won't work on mobile
+      if (isDesktop()) BlocProvider(create: (context) => discordBloc), 
     ], child: const IntifaceCentralView());
   }
 

--- a/lib/page/settings_page.dart
+++ b/lib/page/settings_page.dart
@@ -148,6 +148,13 @@ class SettingPage extends StatelessWidget {
               initialValue: cubit.restoreWindowLocation,
               onToggle: (value) => cubit.restoreWindowLocation = value,
               title: const Text("Restore Window Location on Start")));
+
+      appSettingsTiles.insert(
+          3,
+          SettingsTile.switchTile(
+              initialValue: cubit.useDiscordRichPresence,
+              onToggle: (value) => cubit.useDiscordRichPresence = value,
+              title: const Text("Enable Discord Rich Presence")));
     }
 
     tiles.addAll([

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -62,6 +62,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  buffer:
+    dependency: transitive
+    description:
+      name: buffer
+      sha256: "389da2ec2c16283c8787e0adaede82b1842102f8c8aae2f49003a766c5c6b3d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
   build:
     dependency: transitive
     description:
@@ -254,6 +262,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  discord_rich_presence:
+    dependency: "direct main"
+    description:
+      name: discord_rich_presence
+      sha256: ed30f3aa310fb96afe1d410ac0263f4f3013943981935332db08a037f340f4fd
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   easy_debounce:
     dependency: "direct main"
     description:
@@ -1118,10 +1134,10 @@ packages:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   url_launcher:
     dependency: "direct main"
     description:
@@ -1190,10 +1206,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: "83d37c7ad7aaf9aa8e275490669535c8080377cfa7a7004c24dfac53afffaa90"
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.2"
+    version: "4.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -1299,5 +1315,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=3.5.0-259.0.dev <4.0.0"
+  dart: ">=3.5.3 <4.0.0"
   flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   window_manager: ^0.3.7
   multicast_dns: ^0.3.2+6
   flutter_multi_slider: ^2.0.0
+  discord_rich_presence: ^1.1.1
 
 dev_dependencies:
   build_runner: ^2.4.6


### PR DESCRIPTION
This PR adds support to display Intiface Central's status through Discord Rich Presence (via its IPC api).

This also adds a setting for it which is disabled by default.
It's also only available on desktop but is fully cross-platform, tested on Windows and Linux (macOS implementation is the same as far as I know).

Could easily be improved, honestly, I have never touched Bloc/Cubit before this and I'm pretty sure this could have been implemented in a better way than this.

This also uses a new environment variable named "DISCORD_CLIENT_ID" which should match a client_id provided by a Discord application.

![image](https://github.com/user-attachments/assets/c85e289b-2611-4359-903b-19a3f89e0250)