### PR TITLE
Remove platform gate on HID

### DIFF
--- a/lib/bloc/configuration/intiface_configuration_cubit.dart
+++ b/lib/bloc/configuration/intiface_configuration_cubit.dart
@@ -360,10 +360,7 @@ class IntifaceConfigurationCubit extends Cubit<IntifaceConfigurationState> {
     emit(UseSerialPortState(value));
   }
 
-  bool get useHID {
-    if (Platform.isWindows) return _prefs.getBool("useHID")!;
-    return false;
-  }
+  bool get useHID => _prefs.getBool("useHID")!;
 
   set useHID(bool value) {
     _prefs.setBool("useHID", value);

--- a/lib/widget/engine_config_widget.dart
+++ b/lib/widget/engine_config_widget.dart
@@ -138,15 +138,15 @@ class EngineConfigWidget extends StatelessWidget {
               initialValue: cubit.useXInput,
               onToggle: (value) => cubit.useXInput = value,
               title: const Text("XBox Compatible Gamepads (XInput)")),
-          SettingsTile.switchTile(
-              enabled: !engineIsRunning,
-              initialValue: cubit.useHID,
-              onToggle: (value) => cubit.useHID = value,
-              title: const Text("HID Devices (Joycon, etc...)"))
         ]);
       }
 
       deviceSettings.addAll([
+        SettingsTile.switchTile(
+            enabled: !engineIsRunning,
+            initialValue: cubit.useHID,
+            onToggle: (value) => cubit.useHID = value,
+            title: const Text("HID Devices (Joycon, etc...)"))
         SettingsTile.switchTile(
             enabled: !engineIsRunning,
             initialValue: cubit.useLovenseConnectService,


### PR DESCRIPTION
(See https://github.com/buttplugio/buttplug/pull/686 for context on macOS HID fix)
Unlike XInput, HID *should* work on all desktop platforms, so I think it's sensible to give users the option to enable this. It would be nice to confirm that HID works on Linux before merging this, but I don't see any downside as it stands.