### PR TITLE
fix: macOS UI Issues, Engine stop functionality and logging improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,4 @@ app.*.symbols
 # New android build system files
 **/.cxx
 
-target/
+target/CLAUDE.md

--- a/lib/bloc/engine/engine_control_bloc.dart
+++ b/lib/bloc/engine/engine_control_bloc.dart
@@ -163,7 +163,8 @@ class EngineControlBloc extends Bloc<EngineControlEvent, EngineControlState> {
     });
     on<EngineControlEventStop>((event, emit) async {
       await _repo.stop();
-      //return emit(EngineStoppedState());
+      _isRunning = false;
+      emit(EngineStoppedState());
     });
   }
 

--- a/lib/bloc/engine/engine_repository.dart
+++ b/lib/bloc/engine/engine_repository.dart
@@ -60,6 +60,8 @@ class EngineRepository {
 
   Future<void> stop() async {
     await _provider.stop();
+    // Close the stream to end any emit.forEach listeners in the bloc
+    await _engineMessageStream.close();
   }
 
   Future<bool> runtimeStarted() async {

--- a/lib/bloc/update/http_update_provider.dart
+++ b/lib/bloc/update/http_update_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -11,6 +12,10 @@ abstract class HttpUpdateProvider implements UpdateProvider {
   final String _updateUrl;
   String _expectedVersion;
 
+  // Timeout for network operations to prevent hanging on slow/unresponsive servers
+  static const Duration _connectionTimeout = Duration(seconds: 10);
+  static const Duration _responseTimeout = Duration(seconds: 15);
+
   HttpUpdateProvider(this._localFile, this._updateUrl, this._expectedVersion);
 
   Future<String?> internalUpdate() async {
@@ -19,25 +24,42 @@ abstract class HttpUpdateProvider implements UpdateProvider {
       "Running HTTP Update for $_updateUrl with expected version $_expectedVersion",
     );
     HttpClient client = HttpClient();
+    client.connectionTimeout = _connectionTimeout;
 
-    HttpClientRequest req = await client.getUrl(Uri.parse(_updateUrl));
-    // If we don't have a copy of the file locally, skip our version check and always download it.
-    if (await _localFile.exists()) {
-      req.headers.add(HttpHeaders.ifNoneMatchHeader, _expectedVersion);
+    try {
+      HttpClientRequest req = await client.getUrl(Uri.parse(_updateUrl)).timeout(_connectionTimeout);
+      // If we don't have a copy of the file locally, skip our version check and always download it.
+      if (await _localFile.exists()) {
+        req.headers.add(HttpHeaders.ifNoneMatchHeader, _expectedVersion);
+      }
+      HttpClientResponse response = await req.close().timeout(_responseTimeout);
+      if (response.statusCode == 200) {
+        final etag = response.headers.value(HttpHeaders.etagHeader);
+        final stringData = await response.transform(utf8.decoder).join().timeout(_responseTimeout);
+        await _localFile.writeAsString(stringData);
+        _expectedVersion = etag!;
+        logInfo(
+          "HTTP Update for $_updateUrl found new version $_expectedVersion",
+        );
+        return etag;
+      }
+      logDebug("No new version for $_updateUrl found");
+      return null;
+    } on SocketException catch (e) {
+      // Network errors (connection refused, reset, etc.) - non-fatal for updates
+      logWarning("Network error checking for updates at $_updateUrl: $e");
+      return null;
+    } on TimeoutException catch (e) {
+      // Request timed out - non-fatal for updates
+      logWarning("Timeout checking for updates at $_updateUrl: $e");
+      return null;
+    } on HttpException catch (e) {
+      // HTTP protocol errors - non-fatal for updates
+      logWarning("HTTP error checking for updates at $_updateUrl: $e");
+      return null;
+    } finally {
+      client.close();
     }
-    HttpClientResponse response = await req.close();
-    if (response.statusCode == 200) {
-      final etag = response.headers.value(HttpHeaders.etagHeader);
-      final stringData = await response.transform(utf8.decoder).join();
-      await _localFile.writeAsString(stringData);
-      _expectedVersion = etag!;
-      logInfo(
-        "HTTP Update for $_updateUrl found new version $_expectedVersion",
-      );
-      return etag;
-    }
-    logDebug("No new version for $_updateUrl found");
-    return null;
   }
 }
 

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import FlutterMacOS
+import window_manager
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
@@ -11,5 +12,13 @@ class MainFlutterWindow: NSWindow {
     RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()
+  }
+
+  // Required for window_manager to properly handle window initialization on macOS.
+  // Without this, there's a race condition where the window shows before Flutter
+  // is ready, causing waitUntilReadyToShow() to potentially deadlock on first run.
+  override public func order(_ place: NSWindow.OrderingMode, relativeTo otherWin: Int) {
+    super.order(place, relativeTo: otherWin)
+    hiddenWindowAtLaunch()
   }
 }

--- a/rust/src/in_process_frontend.rs
+++ b/rust/src/in_process_frontend.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use crate::frb_generated::StreamSink;
 use futures::FutureExt;
 use intiface_engine::{EngineMessage, Frontend, IntifaceError, IntifaceMessage};
-use std::{future::Future, sync::Arc};
+use std::{future::Future, sync::{Arc, atomic::{AtomicBool, Ordering}}};
 use tokio::sync::{broadcast, Notify};
 
 pub struct FlutterIntifaceEngineFrontend {
@@ -10,6 +10,10 @@ pub struct FlutterIntifaceEngineFrontend {
   sink: StreamSink<String>,
   notify: Arc<Notify>,
   disconnect_notifier: Arc<Notify>,
+  /// Flag to indicate the frontend is closed and should not send messages.
+  /// Prevents "Error dispatching event: SendError { kind: Disconnected }"
+  /// during shutdown when the Dart stream has already been closed.
+  closed: AtomicBool,
 }
 
 impl FlutterIntifaceEngineFrontend {
@@ -19,12 +23,18 @@ impl FlutterIntifaceEngineFrontend {
       sender,
       notify: Arc::new(Notify::new()),
       disconnect_notifier: Arc::new(Notify::new()),
+      closed: AtomicBool::new(false),
     }
   }
 
   pub fn notify_on_creation(&self) -> impl Future + use<> {
     let notify = self.notify.clone();
     async move { notify.notified().await }.boxed()
+  }
+
+  /// Mark the frontend as closed to prevent sending messages after shutdown.
+  pub fn close(&self) {
+    self.closed.store(true, Ordering::SeqCst);
   }
 }
 
@@ -43,9 +53,13 @@ impl Frontend for FlutterIntifaceEngineFrontend {
     self.sender.subscribe()
   }
   async fn send(&self, msg: EngineMessage) {
+    // Check if frontend is closed before sending to avoid SendError during shutdown
+    if self.closed.load(Ordering::SeqCst) {
+      return;
+    }
     if let EngineMessage::EngineServerCreated {} = msg {
       self.notify.notify_waiters();
     }
-    self.sink.add(serde_json::to_string(&msg).unwrap());
+    let _ = self.sink.add(serde_json::to_string(&msg).unwrap());
   }
 }


### PR DESCRIPTION
I used Claude Opus 4.5 to solve some issues I was seeing. I have tested the code and it works for me so far. Even if you decide not to merge this, perhaps it will give you some ideas about some things that it fixed. The app works every time for me now, which was not the case before.

Description:

  Summary

  - Fixed engine stop not completing on macOS: The stop button would show logs but never finish stopping the engine. Root cause was the Dart message stream never closing and EngineStoppedState not being emitted.
  - Fixed Rust-side shutdown blocking: Removed early ENGINE_SHUTDOWN flag that was preventing the engineStopped message from reaching Dart.
  - Added log filtering: Suppressed benign btleplug "SendError" messages that appear during macOS Bluetooth permission flow.

  Additional Fixes

  - macOS first-run UI: Added hiddenWindowAtLaunch() to fix window not appearing until app restart.
  - State flickering: Added cached FutureBuilder to prevent UI flickering on rebuild.
  - Update checker: Added timeouts and error handling to HTTP update provider.

  Changes

  - lib/bloc/engine/engine_control_bloc.dart - Emit EngineStoppedState directly in stop handler
  - lib/bloc/engine/engine_repository.dart - Close stream when stopping engine
  - rust/src/api/runtime.rs - Remove early shutdown flag blocking messages
  - rust/src/logging.rs - Filter benign btleplug errors
  - rust/src/in_process_frontend.rs - Add closed flag for frontend
  - macos/Runner/MainFlutterWindow.swift - Fix first-run window display
  - lib/intiface_central_app.dart - Cached FutureBuilder
  - lib/bloc/update/http_update_provider.dart - Timeouts and error handling

  Test Plan

  - Verified engine starts successfully
  - Verified engine stops completely when stop button is clicked
  - Verified engine can be restarted after stopping
  - Verified no "SendError" messages in logs during normal operation